### PR TITLE
Don't display tag on invisible players

### DIFF
--- a/src/main/net/rocketeer/sevens/game/name/NameTagRegistry.java
+++ b/src/main/net/rocketeer/sevens/game/name/NameTagRegistry.java
@@ -11,6 +11,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffectType;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -71,7 +72,9 @@ public class NameTagRegistry extends AttributeRegistry<NameTag> {
     if (!isActive())
       return;
     Player target = tag.owner();
-    if (!this.worlds.contains(target.getWorld().getName().toLowerCase()) || target.getGameMode() != GameMode.SURVIVAL) {
+
+    boolean invisible = target.hasPotionEffect(PotionEffectType.INVISIBILITY);
+    if (!this.worlds.contains(target.getWorld().getName().toLowerCase()) || target.getGameMode() != GameMode.SURVIVAL || invisible) {
       this.stopTracking(target);
       return;
     }

--- a/src/test/net/rocketeer/sevens/database/PlayerQueryThroughputTest.java
+++ b/src/test/net/rocketeer/sevens/database/PlayerQueryThroughputTest.java
@@ -15,7 +15,7 @@ public class PlayerQueryThroughputTest {
   public void run() throws Exception {
     long a = System.currentTimeMillis();
     for (int i = 0; i < this.nQueries; ++i)
-      this.database.findPlayer(UUID.randomUUID());
+      this.database.findPlayer(UUID.randomUUID(), false);
     double seconds = (System.currentTimeMillis() - a) / 1000.0;
     System.out.println("Queries per second: " + this.nQueries / seconds);
   }


### PR DESCRIPTION
- Quick hack to stop tracking invisible players.
- Fix PlayerQueryThroughputTest so it compiles.