### PR TITLE
Ignore canceled damage events in rating listener

### DIFF
--- a/src/main/net/rocketeer/sevens/player/listener/KillRatingListener.java
+++ b/src/main/net/rocketeer/sevens/player/listener/KillRatingListener.java
@@ -111,9 +111,9 @@ public class KillRatingListener implements Listener {
     this.logKill(event);
   }
 
-  @EventHandler
+  @EventHandler(ignoreCancelled = true)
   public void onDamageEvent(EntityDamageByEntityEvent event) {
-    if (!(event.getEntity() instanceof Player))
+    if (!(event.getEntity() instanceof Player) || !(event.getDamager() instanceof Player))
       return;
     if (!this.trackedWorlds.contains(event.getEntity().getWorld().getName()))
       return;


### PR DESCRIPTION
- Only record damage events when it isn't canceled and when both entities
  involved are players.