### PR TITLE
Fix memory leak from spree listener

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'idea'
 apply plugin: 'java'
 
-version = '0.1.2'
+version = '0.1.3'
 
 repositories {
     mavenCentral()

--- a/src/main/net/rocketeer/sevens/game/spree/SpreeRegistry.java
+++ b/src/main/net/rocketeer/sevens/game/spree/SpreeRegistry.java
@@ -47,10 +47,12 @@ public class SpreeRegistry extends AttributeRegistry<Integer> {
   }
 
   public class Listener implements org.bukkit.event.Listener {
+    @EventHandler
     public void onWorldChange(PlayerChangedWorldEvent event) {
       endSpree(event.getPlayer());
     }
 
+    @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
       endSpree(event.getPlayer());
       playerToSpree.remove(event.getPlayer());

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: 777
 main: net.rocketeer.sevens.SevensPlugin
-version: 0.1.2
+version: 0.1.3
 depend: [WorldGuard,ProtocolLib]
 commands:
   togglerating:


### PR DESCRIPTION
- Add missing EventHandlers that would remove players from the spree
tracking map.